### PR TITLE
Added lip sync score

### DIFF
--- a/nodes/C_nodes/c1_lip_sync_score.py
+++ b/nodes/C_nodes/c1_lip_sync_score.py
@@ -1,2 +1,71 @@
+import numpy as np
+from scipy.signal import correlate
+from scipy.ndimage import gaussian_filter1d
+from typing import TypedDict, Optional, Dict, Any, Annotated
+import operator
+
 def run(state: dict) -> dict:
+    print(" C1: Analyzing Lip Sync...")
+
+    mouth_landmarks = state.get("mouth_landmarks")
+    audio_onsets = state.get("audio_onsets")
+    metadata = state.get("metadata", {})
+    fps = metadata.get("fps")
+    duration = metadata.get("duration")
+
+    if not mouth_landmarks or not audio_onsets:
+        print(" C1: Warning - Missing mouth landmarks or audio onsets. Cannot compute lip-sync score.")
+        state["lip_sync_score"] = 0.0 #default bad score
+        return state
+
+    if not fps or not duration:
+        print(" C1: Warning - Missing video FPS or duration from metadata. Cannot compute lip-sync score.")
+        state["lip_sync_score"] = 0.0
+        return state
+
+    
+    #both signals should be compared with same time axis
+    num_frames = int(duration * fps)
+    time_axis = np.linspace(0, duration, num_frames)
+
+    #use mouth aspect ratio for getting mouth movements
+    mouth_timestamps = [lm['timestamp'] for lm in mouth_landmarks]
+    mouth_mar_values = [lm['mar'] for lm in mouth_landmarks]
+    
+    #interpolate with our time axis
+    mouth_signal = np.interp(time_axis, mouth_timestamps, mouth_mar_values)
+
+    #get audio signal
+    audio_signal = np.zeros_like(time_axis)
+    for onset_time in audio_onsets:
+        idx = np.searchsorted(time_axis, onset_time, side="left")
+        if idx < len(audio_signal):
+            audio_signal[idx] = 1.0
+    
+    #smooth signal using gaussian filters
+    audio_signal = gaussian_filter1d(audio_signal, sigma=2)
+
+    #normalize (v important)
+    epsilon = 1e-9
+    mouth_signal_norm = (mouth_signal - np.mean(mouth_signal)) / (np.std(mouth_signal) + epsilon)
+    audio_signal_norm = (audio_signal - np.mean(audio_signal)) / (np.std(audio_signal) + epsilon)
+
+    
+    max_lag_frames = int(fps * 0.5)
+    sub_mouth_signal = mouth_signal_norm[max_lag_frames:-max_lag_frames]
+    
+    # `correlate` will check lags from -max_lag_frames to +max_lag_frames
+    correlation = correlate(audio_signal_norm, sub_mouth_signal, mode='valid', method='fft')
+    
+    normalized_correlation = correlation / len(sub_mouth_signal)
+
+    # The lip-sync score is the maximum positive correlation found within the lag window.
+    # We are interested in positive correlation (mouth opens when sound occurs).
+    # We use np.max and clamp it at 0, as a negative correlation implies anti-sync.
+    score = np.max(normalized_correlation)
+    lip_sync_score = max(0.0, float(score))
+
+    print(f" C1: Lip Sync Analysis Complete. Score: {lip_sync_score:.4f}")
+    state["lip_sync_score"] = lip_sync_score
+
     return state

--- a/tests/test_c1_lip_sync_score.py
+++ b/tests/test_c1_lip_sync_score.py
@@ -1,0 +1,182 @@
+import unittest
+import os
+import sys
+import numpy as np
+
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+from nodes.C_nodes.c1_lip_sync_score import run as c1_run
+
+class TestC1LipSyncScore(unittest.TestCase):
+
+    def setUp(self):
+        self.base_state: State = {
+            "metadata": {"duration": 5.0, "fps": 30.0},
+            "debug": False,
+            "input_path": "", "label": None, "data_dir": None,
+            "fake_probability": None, "transcript": None, "segments": None,
+            "word_count": None, "onset_count": None, "keyframes": None,
+            "face_detections": None, "ocr_results": None, "mouth_landmarks_viz_path": None,
+            "blink_data": None, "head_pose_data": None, "headpose_viz_path": None,
+            "audio_onsets": [], "mouth_landmarks": [], "lip_sync_score": None
+        }
+
+    @staticmethod
+    def generate_mouth_data(timestamps, mar_peaks_times, base_mar=0.05, peak_mar=0.7, peak_width=0.1):
+        landmarks = []
+        for t in timestamps:
+            mar = base_mar
+            if any(abs(t - peak_time) < peak_width for peak_time in mar_peaks_times):
+                mar = peak_mar
+            landmarks.append({"timestamp": t, "mar": mar})
+        return landmarks
+
+    def test_perfect_sync(self):
+        """
+        Tests a scenario where mouth MAR peaks exactly at audio onsets.
+        The expected score should be very high.
+        """
+        state = self.base_state.copy()
+        duration = state["metadata"]["duration"]
+        fps = state["metadata"]["fps"]
+        num_frames = int(duration * fps)
+        timestamps = np.linspace(0, duration, num_frames)
+        
+        onset_times = [1.0, 2.5, 4.0]
+        state["audio_onsets"] = onset_times
+        state["mouth_landmarks"] = self.generate_mouth_data(timestamps, mar_peaks_times=onset_times)
+        
+        result_state = c1_run(state)
+        
+        self.assertIn("lip_sync_score", result_state)
+        self.assertIsNotNone(result_state["lip_sync_score"])
+        self.assertGreater(result_state["lip_sync_score"], 0.8, "Score should be high for perfect sync")
+
+    def test_delayed_sync(self):
+        """
+        Tests a scenario where mouth movements are slightly delayed.
+        Cross-correlation should still find a high score.
+        """
+        state = self.base_state.copy()
+        duration = state["metadata"]["duration"]
+        fps = state["metadata"]["fps"]
+        num_frames = int(duration * fps)
+        timestamps = np.linspace(0, duration, num_frames)
+        
+        onset_times = [1.0, 2.5, 4.0]
+        delay = 0.12  # 120ms delay
+        mouth_peak_times = [t + delay for t in onset_times]
+        state["audio_onsets"] = onset_times
+        state["mouth_landmarks"] = self.generate_mouth_data(timestamps, mar_peaks_times=mouth_peak_times)
+        
+        result_state = c1_run(state)
+        
+        self.assertIn("lip_sync_score", result_state)
+        self.assertGreater(result_state["lip_sync_score"], 0.7, "Score should be high for delayed sync")
+
+    def test_no_sync(self):
+        """
+        Tests where mouth movements are unrelated to audio onsets.
+        The expected score should be very low.
+        """
+        state = self.base_state.copy()
+        duration = state["metadata"]["duration"]
+        fps = state["metadata"]["fps"]
+        num_frames = int(duration * fps)
+        timestamps = np.linspace(0, duration, num_frames)
+        
+        onset_times = [1.0, 2.5, 4.0]
+        mouth_peak_times = [0.5, 1.8, 3.3] # Unrelated times
+        state["audio_onsets"] = onset_times
+        state["mouth_landmarks"] = self.generate_mouth_data(timestamps, mar_peaks_times=mouth_peak_times)
+        
+        result_state = c1_run(state)
+        
+        self.assertIn("lip_sync_score", result_state)
+        self.assertLess(result_state["lip_sync_score"], 0.25, "Score should be low for no sync")
+
+    def test_anti_sync(self):
+        """
+        Tests where the mouth is closed during audio onsets.
+        The score should be very low, not necessarily exactly zero.
+        """
+        state = self.base_state.copy()
+        duration = state["metadata"]["duration"]
+        fps = state["metadata"]["fps"]
+        num_frames = int(duration * fps)
+        timestamps = np.linspace(0, duration, num_frames)
+        onset_times = [1.0, 2.5, 4.0]
+
+        landmarks = [{"timestamp": t, "mar": 0.05} for t in timestamps]
+        for lm in landmarks:
+            if not any(abs(lm['timestamp'] - onset) < 0.1 for onset in onset_times):
+                lm['mar'] = 0.7
+        
+        state["audio_onsets"] = onset_times
+        state["mouth_landmarks"] = landmarks
+
+        result_state = c1_run(state)
+
+        self.assertIn("lip_sync_score", result_state)
+        self.assertLess(result_state["lip_sync_score"], 0.25, "Score should be very low for anti-sync")
+    
+    def test_missing_data_returns_zero(self):
+        """Tests that missing essential data lists results in a score of 0.0."""
+        with self.subTest(msg="Missing mouth_landmarks"):
+            state = self.base_state.copy()
+            state["audio_onsets"] = [1.0]
+            state["mouth_landmarks"] = [] 
+            result_state = c1_run(state)
+            self.assertEqual(result_state["lip_sync_score"], 0.0)
+
+        with self.subTest(msg="Missing audio_onsets"):
+            state = self.base_state.copy()
+            state["audio_onsets"] = [] 
+            state["mouth_landmarks"] = [{"timestamp": 1.0, "mar": 0.5}]
+            result_state = c1_run(state)
+            self.assertEqual(result_state["lip_sync_score"], 0.0)
+
+    def test_missing_metadata_returns_zero(self):
+        """Tests that missing essential metadata results in a score of 0.0."""
+        with self.subTest(msg="Missing metadata 'fps'"):
+            state = self.base_state.copy()
+            state["audio_onsets"] = [1.0]
+            state["mouth_landmarks"] = [{"timestamp": 1.0, "mar": 0.5}]
+            del state["metadata"]["fps"]
+            result_state = c1_run(state)
+            self.assertEqual(result_state["lip_sync_score"], 0.0)
+
+        with self.subTest(msg="Missing metadata 'duration'"):
+            state = self.base_state.copy()
+            state["audio_onsets"] = [1.0]
+            state["mouth_landmarks"] = [{"timestamp": 1.0, "mar": 0.5}]
+            del state["metadata"]["duration"]
+            result_state = c1_run(state)
+            self.assertEqual(result_state["lip_sync_score"], 0.0)
+
+    def test_no_activity_returns_zero(self):
+        """Tests that no variation in signals results in a score of 0.0."""
+        duration = self.base_state["metadata"]["duration"]
+        fps = self.base_state["metadata"]["fps"]
+        num_frames = int(duration * fps)
+        timestamps = np.linspace(0, duration, num_frames)
+
+        with self.subTest(msg="No audio activity"):
+            state = self.base_state.copy()
+            state["audio_onsets"] = []
+            state["mouth_landmarks"] = self.generate_mouth_data(timestamps, mar_peaks_times=[1.0, 2.5])
+            result_state = c1_run(state)
+            self.assertEqual(result_state["lip_sync_score"], 0.0)
+        
+        with self.subTest(msg="No mouth activity"):
+            state = self.base_state.copy()
+            state["audio_onsets"] = [1.0, 2.5]
+            state["mouth_landmarks"] = [{"timestamp": t, "mar": 0.1} for t in timestamps]
+            result_state = c1_run(state)
+            self.assertAlmostEqual(result_state["lip_sync_score"], 0.0, places=7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two files have been modified/added. One with the node logic, one for testing.

Base logic is:
- Get the rough "mouth signal" using mouth aspect ratio, audio signal using the audio onsets
- Normalize them using the same time axis
- Cross Correlate them to get a final score (fft for fast calculation : see https://docs.scipy.org/doc//scipy-1.16.2/reference/generated/scipy.signal.correlate.html)

Tests include:
- Perfect sync
- Anti-sync
- Delayed sync
- Missing values handling